### PR TITLE
add chunked processing

### DIFF
--- a/ciso.py
+++ b/ciso.py
@@ -18,7 +18,7 @@ CISO_HEADER_FMT = '<LLQLBBxx' # Little endian
 CISO_PLAIN_BLOCK = 0x80000000
 
 CISO_SPLIT_SIZE = 0xFFBF6000
-CHUNK_SIZE      = 128 * 1024 # 1MB chunk size
+CHUNK_SIZE      = 128 * 1024
 CHUNK_SIZE_SECT = int(CHUNK_SIZE / CISO_BLOCK_SIZE)
 MP_NUM_CHUNKS   = 64 # number of chunks to read for multiprocessing
 MP_CHUNK_SIZE   = MP_NUM_CHUNKS * CHUNK_SIZE

--- a/ciso.py
+++ b/ciso.py
@@ -168,9 +168,8 @@ def compress_iso(infile):
 		percent_period = ciso['total_blocks'] / 100
 		percent_cnt = 0
 
-		split_fout   = fout_1
-		out_bytes    = bytearray()
-		chunks_total = math.ceil(ciso['total_blocks'] / CHUNK_SIZE_SECT)
+		split_fout      = fout_1
+		out_bytes       = bytearray()
 		mp_chunks_total = math.ceil(ciso['total_bytes'] / MP_CHUNK_SIZE)
 
 		# read in several chunks at once
@@ -180,10 +179,10 @@ def compress_iso(infile):
 			del mp_chunk_data
 			mp_chunk_data_list_len = len(mp_chunk_data_list)
 			mp_chunk_data_len_list = []
-			mp_chunk_list = []
+			mp_chunk_list          = []
 
 			# split each chunk into a sectors list
-			for idx, chunk_data in enumerate(mp_chunk_data_list):
+			for chunk_data in mp_chunk_data_list:
 				sector_list = [chunk_data[i: i + CISO_BLOCK_SIZE] for i in range(0, len(chunk_data), CISO_BLOCK_SIZE)]
 				mp_chunk_data_len_list.append(len(chunk_data))
 				mp_chunk_list.append(sector_list)
@@ -195,7 +194,7 @@ def compress_iso(infile):
 
 			# setup chunk/sector mapping
 			for chunk in range(0, mp_chunk_data_list_len):
-				chunk_len = mp_chunk_data_len_list[chunk]
+				chunk_len         = mp_chunk_data_len_list[chunk]
 				chunk_sectors_len = CHUNK_SIZE_SECT
 
 				sector_list     = mp_chunk_list[chunk]

--- a/ciso.py
+++ b/ciso.py
@@ -18,7 +18,7 @@ CISO_HEADER_FMT = '<LLQLBBxx' # Little endian
 CISO_PLAIN_BLOCK = 0x80000000
 
 CISO_SPLIT_SIZE = 0xFFBF6000
-CHUNK_SIZE      = 1 * 1024 * 1024 # 1MB chunk size
+CHUNK_SIZE      = 128 * 1024 # 1MB chunk size
 CHUNK_SIZE_SECT = int(CHUNK_SIZE / CISO_BLOCK_SIZE)
 MP_NUM_CHUNKS   = 64 # number of chunks to read for multiprocessing
 MP_CHUNK_SIZE   = MP_NUM_CHUNKS * CHUNK_SIZE

--- a/ciso.py
+++ b/ciso.py
@@ -26,8 +26,8 @@ MP_NUM_CHUNKS = 64 # number of chunks to read for multiprocessing
 MP_CHUNK_SIZE = MP_NUM_CHUNKS * CHUNK_SIZE
 MP_CHUNK_SECT = MP_CHUNK_SIZE / CISO_BLOCK_SIZE
 
-CMP_LIST_SMH_PAD  = 4 # pad bytes for each sector in compressed list shm
-CMP_LIST_SMH_PAD_SIZE = (CISO_BLOCK_SIZE + CMP_LIST_SMH_PAD) * CHUNK_NUM_SECT * MP_NUM_CHUNKS
+CMP_LIST_SHM_PAD  = 4 # pad bytes for each sector in compressed list shm
+CMP_LIST_SHM_PAD_SIZE = (CISO_BLOCK_SIZE + CMP_LIST_SHM_PAD) * CHUNK_NUM_SECT * MP_NUM_CHUNKS
 SHM_IN_SECT_NAME  = 'ciso_shm_in_sectors'
 SHM_CMP_SECT_NAME = 'ciso_shm_cmp_sectors'
 
@@ -147,7 +147,7 @@ def compress_chunk(chunk):
 		out_bytes = bytearray()
 
 		in_offset  = chunk * CHUNK_SIZE
-		out_offset = chunk * CHUNK_NUM_SECT * CMP_LIST_SMH_PAD + in_offset
+		out_offset = chunk * CHUNK_NUM_SECT * CMP_LIST_SHM_PAD + in_offset
 
 		chunk_data  = bytearray(inshm.buf[in_offset: in_offset + CHUNK_SIZE])
 		num_sectors = math.ceil(len(chunk_data) / CISO_BLOCK_SIZE)
@@ -181,7 +181,7 @@ def compress_chunk(chunk):
 def compress_iso(infile):
 	pool   = multiprocessing.Pool()
 	inshm  = multiprocessing.shared_memory.SharedMemory(name=SHM_IN_SECT_NAME, create=True, size=MP_CHUNK_SIZE)
-	cmpshm = multiprocessing.shared_memory.SharedMemory(name=SHM_CMP_SECT_NAME, create=True, size=CMP_LIST_SMH_PAD_SIZE)
+	cmpshm = multiprocessing.shared_memory.SharedMemory(name=SHM_CMP_SECT_NAME, create=True, size=CMP_LIST_SHM_PAD_SIZE)
 
 	# Replace file extension with .cso
 	fout_1 = open(os.path.splitext(infile)[0] + '.1.cso', 'wb')
@@ -244,7 +244,7 @@ def compress_iso(infile):
 
 			for chunk, compressed_sizes_list in enumerate(compressed_sizes):
 				chunk_offset     = chunk * CHUNK_SIZE
-				cmp_chunk_offset = chunk * CHUNK_NUM_SECT * CMP_LIST_SMH_PAD + chunk_offset
+				cmp_chunk_offset = chunk * CHUNK_NUM_SECT * CMP_LIST_SHM_PAD + chunk_offset
 				cmp_sect_offset  = 0
 
 				for sector, compressed_size in enumerate(compressed_sizes_list):


### PR DESCRIPTION
This branch adds chunked processing for a potential compression speed-up of up to 60%, depending on source drive speed. YMMV. At worst, it will break-even. Works great when processing over SMB.