### PR TITLE
attach.xbe generation & patching

### DIFF
--- a/ciso.py
+++ b/ciso.py
@@ -252,6 +252,9 @@ def get_iso_root_dir_offset_and_size(iso_file):
 	iso_header_offset    = 0x10000
 	root_dir_sect_offset = 0x14
 
+	root_dir_offset = 0
+	root_dir_size   = 0
+
 	with open(iso_file, 'rb') as f:
 		detect_iso_type(f)
 
@@ -360,7 +363,6 @@ def get_xbe_section_offsets_from_bytes(header_bytes, search_section):
 		name_offset = name_addr - base_addr
 		name = readcstr(header_bytes, name_offset)
 
-		# title image section
 		if name == search_section:
 			return offset, raw_addr, raw_size
 

--- a/ciso.py
+++ b/ciso.py
@@ -713,12 +713,12 @@ def move_output_files(iso_file, output_name = '', len_limit = 255):
 	cios1_file = iso_base_name + cso_1_ext
 	cios2_file = iso_base_name + cso_2_ext
 
-	out_dir    = base_dir + '/' + safe_title
-	ciso1      = base_dir + '/' + cios1_file
-	ciso2      = base_dir + '/' + cios2_file
-	new_file   = out_dir  + '/' + os.path.basename(out_file_name)
-	new_cios1  = out_dir  + '/' + safe_title_trunc + cso_1_ext
-	new_cios2  = out_dir  + '/' + safe_title_trunc + cso_2_ext
+	out_dir   = base_dir + '/' + safe_title
+	ciso1     = base_dir + '/' + cios1_file
+	ciso2     = base_dir + '/' + cios2_file
+	new_file  = out_dir  + '/' + os.path.basename(out_file_name)
+	new_cios1 = out_dir  + '/' + safe_title_trunc + cso_1_ext
+	new_cios2 = out_dir  + '/' + safe_title_trunc + cso_2_ext
 
 	if not os.path.isdir(out_dir):
 		os.makedirs(out_dir)

--- a/ciso.py
+++ b/ciso.py
@@ -793,9 +793,9 @@ def move_output_files(iso_file, output_name = '', len_limit = 255):
 		output_name = os.path.splitext(os.path.basename(iso_file))[0]
 		output_name = output_name.strip()
 
-	keepcharacters = (' ', '.', '_', '-')
-	safe_title     = "".join(c for c in output_name if c.isalnum() or c in keepcharacters).rstrip()
-	safe_title     = re.sub('\s+', ' ', safe_title)
+	keepchars  = list(" ._-()[]&$!'#@%^{}~`")
+	safe_title = "".join(c for c in output_name if c.isalnum() or c in keepchars).rstrip()
+	safe_title = re.sub('\s+', ' ', safe_title)
 	safe_title_trunc = safe_title[0:len_limit - 6]
 	ext = get_compress_mode().lower()
 

--- a/ciso.py
+++ b/ciso.py
@@ -10,6 +10,7 @@ import shutil
 import math
 import lz4.frame
 import json
+import re
 
 CISO_MAGIC = 0x4F534943 # CISO
 CISO_HEADER_SIZE = 0x18 # 24
@@ -792,8 +793,9 @@ def move_output_files(iso_file, output_name = '', len_limit = 255):
 		output_name = os.path.splitext(os.path.basename(iso_file))[0]
 		output_name = output_name.strip()
 
-	keepcharacters   = (' ', '.', '_', '-')
-	safe_title       = "".join(c for c in output_name if c.isalnum() or c in keepcharacters).rstrip()
+	keepcharacters = (' ', '.', '_', '-')
+	safe_title     = "".join(c for c in output_name if c.isalnum() or c in keepcharacters).rstrip()
+	safe_title     = re.sub('\s+', ' ', safe_title)
 	safe_title_trunc = safe_title[0:len_limit - 6]
 	ext = get_compress_mode().lower()
 

--- a/ciso.py
+++ b/ciso.py
@@ -6,13 +6,17 @@
 import os
 import struct
 import sys
+import math
 import lz4.frame
+import json
 
 CISO_MAGIC = 0x4F534943 # CISO
 CISO_HEADER_SIZE = 0x18 # 24
 CISO_BLOCK_SIZE = 0x800 # 2048
 CISO_HEADER_FMT = '<LLQLBBxx' # Little endian
 CISO_PLAIN_BLOCK = 0x80000000
+
+TITLE_MAX_LENGTH = 40
 
 #assert(struct.calcsize(CISO_HEADER_FMT) == CISO_HEADER_SIZE)
 
@@ -221,9 +225,477 @@ def compress_iso(infile):
 		pad_file_size(fout_2)
 		fout_2.close()
 
+def is_xbe_file(xbe, offset = 0):
+	if not os.path.isfile(xbe):
+		return False
+
+	with open(xbe, 'rb') as xbe_file:
+		xbe_file.seek(offset)
+		magic = xbe_file.read(4)
+
+		if magic != b'XBEH':
+			return False
+
+	return True
+
+def get_iso_root_dir_offset_and_size(iso_file):
+	global image_offset
+
+	iso_header_offset    = 0x10000
+	root_dir_sect_offset = 0x14
+
+	with open(iso_file, 'rb') as f:
+		detect_iso_type(f)
+
+		f.seek(image_offset + iso_header_offset + root_dir_sect_offset)
+		root_dir_sect    = struct.unpack('<I', f.read(4))[0]
+		root_dir_offset  = image_offset + root_dir_sect * CISO_BLOCK_SIZE
+		root_dir_size    = struct.unpack('<I', f.read(4))[0]
+
+	return root_dir_offset, root_dir_size
+
+def get_file_offset_in_iso(iso_file, search_file):
+	global image_offset
+
+	file_offset, file_size = get_iso_root_dir_offset_and_size(iso_file)
+
+	for item in search_file.split('\\'):
+		file_offset, file_size = get_iso_entry_offset_and_size(iso_file, item, file_offset, file_size)
+
+		if file_offset == 0 or file_size == 0:
+			return 0
+
+		file_offset += image_offset
+
+	return file_offset
+
+def get_iso_entry_offset_and_size(iso_file, search_file, dir_offset, dir_size):
+	dir_ent_size = 0xe
+	dword        = 4
+
+	search_file = search_file.casefold()
+
+	with open(iso_file, 'rb') as f:
+		# seek to dir
+		dir_sectors = math.ceil(dir_size / CISO_BLOCK_SIZE)
+		f.seek(dir_offset)
+
+		dir_bytes        = f.read(dir_sectors * CISO_BLOCK_SIZE)
+		dir_sector_bytes = [dir_bytes[i: i + CISO_BLOCK_SIZE] for i in range(0, len(dir_bytes), CISO_BLOCK_SIZE)]
+
+		# loop through dir entries
+		for sector_bytes in dir_sector_bytes:
+			cur_pos = 0
+
+			while True:
+				cur_pos_diff = CISO_BLOCK_SIZE - cur_pos
+
+				if cur_pos_diff <= 1:
+					break
+
+				dir_ent  = sector_bytes[cur_pos: cur_pos + dir_ent_size]
+				cur_pos += dir_ent_size
+				l_offset = struct.unpack('<H', dir_ent[0:2])[0]
+
+				if l_offset == 0xffff:
+					break
+
+				r_offset     = struct.unpack('<H', dir_ent[2:4])[0]
+				start_sector = struct.unpack('<I', dir_ent[4:8])[0]
+				file_size    = struct.unpack('<I', dir_ent[8:12])[0]
+				attribs      = struct.unpack('<B', dir_ent[12:13])[0]
+				filename_len = struct.unpack('<B', dir_ent[13:14])[0]
+				filename     = sector_bytes[cur_pos: cur_pos + filename_len].decode('utf-8')
+
+				#print("entry: %04X %04X %08X %02X" % (l_offset, r_offset, start_sector, attribs), file_size, filename_len, filename)
+
+				# entries are aligned on 4 byte bounderies
+				next_offset = (dword - ((dir_ent_size + filename_len) % dword)) % dword
+				cur_pos += filename_len + next_offset
+
+				# our entry was found, return the offset
+				if filename.casefold() == search_file:
+					ret_offset = start_sector * CISO_BLOCK_SIZE
+					return ret_offset, file_size
+
+	# entry wasn't found
+	return 0, 0
+
+def get_xbe_section_offsets_from_bytes(header_bytes, search_section):
+	section_header_size = 0x38
+	base_addr_offset    = 0x104
+	cert_addr_offset    = 0x118
+	num_sections_offset = 0x11c
+	sect_headers_offset = 0x120
+
+	base_addr         = struct.unpack('<I', header_bytes[base_addr_offset: base_addr_offset + 4])[0]
+	cert_addr         = struct.unpack('<I', header_bytes[cert_addr_offset: cert_addr_offset + 4])[0]
+	num_sections      = struct.unpack('<I', header_bytes[num_sections_offset: num_sections_offset + 4])[0]
+	sect_headers_addr = struct.unpack('<I', header_bytes[sect_headers_offset: sect_headers_offset + 4])[0]
+
+	# section headers
+	for i in range(0, num_sections):
+		offset = sect_headers_addr - base_addr + i * section_header_size
+		sect_header_bytes = header_bytes[offset: offset + section_header_size]
+
+		flags     = sect_header_bytes[0:4]
+		rv_addr   = sect_header_bytes[4:8]
+		rv_size   = sect_header_bytes[8:12]
+		raw_addr  = sect_header_bytes[12:16]
+		raw_size  = sect_header_bytes[16:20]
+		name_addr = sect_header_bytes[20:24]
+
+		raw_addr  = struct.unpack('<I', raw_addr)[0]
+		raw_size  = struct.unpack('<I', raw_size)[0]
+		name_addr = struct.unpack('<I', name_addr)[0]
+
+		name_offset = name_addr - base_addr
+		name = readcstr(header_bytes, name_offset)
+
+		# title image section
+		if name == search_section:
+			return offset, raw_addr, raw_size
+
+	return 0, 0, 0
+
+def get_xbe_section_offsets(xbe_file, search_section, xbe_offset = 0):
+	xbe_header_size = 0x1000
+	num_pages = 10
+
+	if type(xbe_file) == bytearray or type(xbe_file) == bytes:
+		header_bytes = xbe_file[xbe_offset: xbe_offset + xbe_header_size * num_pages]
+	else:
+		with open(xbe_file, 'rb') as f:
+			f.seek(xbe_offset)
+			header_bytes = f.read(xbe_header_size * num_pages)
+
+	header_offset, raw_offset, raw_size = get_xbe_section_offsets_from_bytes(header_bytes, search_section)
+
+	if not header_offset:
+		xbe_offset = 0
+
+	return xbe_offset + header_offset, xbe_offset + raw_offset, raw_size
+
+# returns array with section header and raw bytes
+def get_xbe_section_bytes(xbe_file, search_section, xbe_offset = 0):
+	section_header_size = 0x38
+
+	ret_header_bytes = None
+	ret_raw_bytes    = None
+
+	header_offset, raw_offset, raw_size = get_xbe_section_offsets(xbe_file, search_section, xbe_offset)
+
+	if header_offset:
+		with open(xbe_file, 'rb') as f:
+			f.seek(header_offset)
+			ret_header_bytes = f.read(section_header_size)
+
+			f.seek(raw_offset)
+			ret_raw_bytes = f.read(raw_size)
+
+	return ret_header_bytes, ret_raw_bytes
+
+# read C-style strings
+def readcstr(bytes, start):
+	end = bytes.find(b'\0', start)
+	sub = bytes[start: end]
+
+	return sub.decode()
+
+def format_title_bytes(title):
+	title = title[0: TITLE_MAX_LENGTH].strip()
+	title = title.ljust(TITLE_MAX_LENGTH, "\x00")
+	title_bytes = title.encode('utf-16-le')
+
+	return title_bytes
+
+def get_iso_file_title_bytes(iso_file):
+	title = os.path.splitext(os.path.basename(iso_file))[0]
+	title_bytes = format_title_bytes(title)
+	return title_bytes
+
+# Some discs have better data from alternate XBEs
+def get_alt_xbe_from_iso(iso_file, title_id = 0, title = None, version = None):
+	xbe_file = None
+
+	if title_id:
+		# Forza Motorsport + XBLA
+		if title_id == 0x584C8014 and title == 'CDX':
+			xbe_file = 'Forza.xbe'
+		# NCAA Football 2005 + Top Spin
+		elif title_id == 0x584C000F and title == 'CDX':
+			xbe_file = 'NCAA\\DEFAULT.XBE'
+		# Hitman 2: Silent Assassin (Rev 2)
+		elif title_id == 0x45530009 and title == 'CDX':
+			xbe_file = 'hm2.xbe'
+		# Star Wars: The Clone Wars + Tetris Worlds
+		elif title_id == 0x584C000D and title == 'CDX':
+			xbe_file = 'CW\\default.xbe'
+		# Ninja Gaiden Video + Dead or Alive X-Treme Beach Volleyball Video + DOA 3 Bonus Materials
+		elif title_id == 0x54438005 and title == 'Xbox Demos':
+			xbe_file = 'Doa3\\doa3b.xbe'
+		# Outlaw Golf: 9 Holes of X-Mas
+		elif title_id == 0x5655801B and title == 'Xbox Demos':
+			xbe_file = 'OGXmas\\OLGDemo.xbe'
+		# Outlaw Golf: Holiday Golf
+		elif title_id == 0x53538005 and title == 'Xbox Demos':
+			xbe_file = 'OGXmas\\OLGDemo.xbe'
+		# Sega GT 2002 + Jet Set Radio Future
+		elif title_id == 0x4D53003D and title == 'Xbox Demos':
+			xbe_file = 'SegaGT.xbe'
+		# World Series Baseball
+		elif title_id == 0x5345000E:
+			xbe_file = 'wsb2k3_xbox_rel.xbe'
+		# NCAA College Basketball 2K3
+		elif title_id == 0x53450018:
+			xbe_file = 'game.xbe'
+
+	return xbe_file
+
+def get_xbe_data_from_iso(iso_file, xbe_file = 'default.xbe'):
+	xbe_header_size       = 0x1000
+	base_addr_offset      = 0x104
+	cert_addr_offset      = 0x118
+	cert_title_id_offset  = 0x8
+	cert_title_offset     = 0xc
+	cert_title_ver_offset = 0xac
+
+	timage_sect_hdr_bytes = None
+	timage_raw_bytes      = None
+
+	xbe_offset = get_file_offset_in_iso(iso_file, xbe_file)
+
+	if xbe_offset == 0:
+		return None
+
+	# pull data from source xbe
+	with open(iso_file, 'rb') as f:
+		f.seek(xbe_offset)
+		header_bytes = f.read(xbe_header_size * 10)
+
+		base_addr = struct.unpack('<I', header_bytes[base_addr_offset: base_addr_offset + 4])[0]
+		cert_addr = struct.unpack('<I', header_bytes[cert_addr_offset: cert_addr_offset + 4])[0]
+
+		# title
+		offset = cert_addr - base_addr + cert_title_offset
+		title_bytes = header_bytes[offset: offset + TITLE_MAX_LENGTH * 2]
+
+		# title id
+		offset = cert_addr - base_addr + cert_title_id_offset
+		title_id_bytes = header_bytes[offset: offset + 4]
+
+		#title version
+		offset = cert_addr - base_addr + cert_title_ver_offset
+		title_ver_bytes = header_bytes[offset: offset + 4]
+
+	title_id  = struct.unpack("<I", title_id_bytes)[0]
+	title_ver = struct.unpack("<I", title_ver_bytes)[0]
+
+	title_id_decoded  = "%08X" % title_id
+	title_ver_decoded = "%08X" % title_ver
+	title_decoded     = title_bytes.decode('utf-16-le').replace('\0', '')
+
+	timage_sect_hdr_bytes, timage_raw_bytes = get_xbe_section_bytes(iso_file, '$$XTIMAGE', xbe_offset)
+
+	return {
+		'title_id':title_id,
+		'title_ver':title_ver,
+		'title_bytes':title_bytes,
+		'title_id_bytes':title_id_bytes,
+		'title_ver_bytes':title_ver_bytes,
+		'title_id_decoded':title_id_decoded,
+		'title_ver_decoded':title_ver_decoded,
+		'title_decoded':title_decoded,
+		'timage_sect_hdr_bytes':timage_sect_hdr_bytes,
+		'timage_raw_bytes':timage_raw_bytes
+	}
+
+def patch_xbe_timage_data(xbe_bytes, timage_sect_hdr_bytes, timage_raw_bytes):
+	title_img_sect_name   = '$$XTIMAGE'
+	num_new_sections      = 1
+	xbe_header_size       = 0x1000
+	section_header_size   = 0x38
+	base_addr_offset      = 0x104
+	num_sections_offset   = 0x11c
+	xbe_img_size_offset   = 0x10c
+	sect_headers_offset   = 0x120
+	sect_digest_offset    = 0x24
+	sect_rv_addr_offset   = 0x4
+	sect_rv_size_offset   = 0x8
+	sect_raw_addr_offset  = 0xc
+	sect_raw_size_offset  = 0x10
+	sect_name_addr_offset = 0x14
+	sect_name_ref_offset  = 0x18
+	sect_head_ref_offset  = 0x1c
+	sect_tail_ref_offset  = 0x20
+	title_img_sect_name_len = len(title_img_sect_name)
+
+	if timage_sect_hdr_bytes != None and timage_raw_bytes != None:
+		title_img_size = len(timage_raw_bytes)
+
+		orig_header_offset, orig_raw_offset, orig_raw_size = get_xbe_section_offsets(xbe_bytes, title_img_sect_name)
+
+		# patch existing $$XTIMAGE section
+		if orig_header_offset:
+			if title_img_size <= orig_raw_size:
+				size_start_offset = orig_header_offset + sect_rv_size_offset
+				raw_size_start_offset = orig_header_offset + sect_raw_size_offset
+				xbe_bytes[size_start_offset: size_start_offset + 4] = struct.pack('<I', title_img_size)
+				xbe_bytes[raw_size_start_offset: raw_size_start_offset + 4] = struct.pack('<I', title_img_size)
+
+				pad_bytes = b'\x00' * (orig_raw_size - title_img_size)
+				timage_raw_bytes += pad_bytes
+				xbe_bytes[orig_raw_offset: orig_raw_offset + orig_raw_size] = timage_raw_bytes
+
+		# no existing $$XTIMAGE section, add it
+		else:
+			base_addr         = struct.unpack('<I', xbe_bytes[base_addr_offset: base_addr_offset + 4])[0]
+			num_sections      = struct.unpack('<I', xbe_bytes[num_sections_offset: num_sections_offset + 4])[0]
+			sect_headers_addr = struct.unpack('<I', xbe_bytes[sect_headers_offset: sect_headers_offset + 4])[0]
+			xbe_size          = struct.unpack('<I', xbe_bytes[xbe_img_size_offset: xbe_img_size_offset + 4])[0] - base_addr
+
+			old_sect_offset = sect_headers_addr - base_addr
+			old_section     = xbe_bytes[old_sect_offset: old_sect_offset + section_header_size * num_sections]
+			new_sect_addr   = xbe_header_size - section_header_size * num_sections - title_img_sect_name_len - num_new_sections - section_header_size
+			new_sect_len    = xbe_header_size - new_sect_addr
+
+			# patch title img section header
+			new_sect_digest_addr = new_sect_addr + section_header_size * num_sections + sect_digest_offset
+			new_sect_name_addr   = new_sect_addr + new_sect_len - title_img_sect_name_len - 1
+			timage_sect_hdr_bytes[sect_rv_addr_offset: sect_rv_addr_offset + 4]     = struct.pack('<I', xbe_size + base_addr)
+			timage_sect_hdr_bytes[sect_rv_size_offset: sect_rv_size_offset + 4]     = struct.pack('<I', title_img_size)
+			timage_sect_hdr_bytes[sect_raw_addr_offset: sect_raw_addr_offset + 4]   = struct.pack('<I', xbe_size)
+			timage_sect_hdr_bytes[sect_raw_size_offset: sect_raw_size_offset + 4]   = struct.pack('<I', title_img_size)
+			timage_sect_hdr_bytes[sect_name_addr_offset: sect_name_addr_offset + 4] = struct.pack('<I', new_sect_name_addr + base_addr)
+			timage_sect_hdr_bytes[sect_name_ref_offset: sect_name_ref_offset + 4]   = bytearray(4)
+			timage_sect_hdr_bytes[sect_digest_offset: sect_digest_offset + 20]      = bytearray(20)
+			timage_sect_hdr_bytes[sect_head_ref_offset: sect_head_ref_offset + 4]   = struct.pack('<I', new_sect_digest_addr + base_addr)
+			timage_sect_hdr_bytes[sect_tail_ref_offset: sect_tail_ref_offset + 4]   = struct.pack('<I', new_sect_digest_addr + 2 + base_addr)
+
+			# placed at the end of the xbe header
+			xbe_bytes[new_sect_addr: new_sect_addr + new_sect_len] = (
+				old_section +
+				timage_sect_hdr_bytes +
+				bytearray(title_img_sect_name.encode()) +
+				b'\0'
+			)
+
+			# patch new data in xbe header
+			xbe_bytes[num_sections_offset: num_sections_offset + 4] = struct.pack('<I', num_sections + num_new_sections)
+			xbe_bytes[sect_headers_offset: sect_headers_offset + 4] = struct.pack('<I', new_sect_addr + base_addr)
+			xbe_bytes[xbe_img_size_offset: xbe_img_size_offset + 4] = struct.pack('<I', xbe_size + title_img_size + base_addr)
+
+			xbe_bytes += timage_raw_bytes
+
+	return xbe_bytes
+
+def gen_attach_xbe(iso_file):
+	me_path       = os.path.dirname(os.path.abspath(__file__))
+	base_dir      = os.path.dirname(os.path.abspath(iso_file))
+	in_file_name  = me_path + '/attach.xbe'
+	json_file     = me_path + '/RepackList.json'
+	out_file_name = base_dir + '/default.xbe'
+
+	if not is_xbe_file(in_file_name):
+		return
+
+	# https://www.caustik.com/cxbx/download/xbe.htm
+	base_addr_offset      = 0x104
+	cert_addr_offset      = 0x118
+	cert_title_id_offset  = 0x8
+	cert_title_offset     = 0xc
+	cert_title_ver_offset = 0xac
+
+	alt_data = None
+	timage_sect_hdr_bytes = None
+	timage_raw_bytes      = None
+
+	xbe_data = get_xbe_data_from_iso(iso_file)
+	alt_xbe  = get_alt_xbe_from_iso(iso_file, xbe_data['title_id'], xbe_data['title_decoded'], xbe_data['title_ver'])
+
+	# We have an alternate xbe to pull data from
+	if alt_xbe:
+		alt_data = get_xbe_data_from_iso(iso_file, alt_xbe)
+
+	timage_raw_bytes      = xbe_data['timage_raw_bytes']
+	timage_sect_hdr_bytes = xbe_data['timage_sect_hdr_bytes']
+	title_bytes           = xbe_data['title_bytes']
+	title_id_bytes        = xbe_data['title_id_bytes']
+	title_ver_bytes       = xbe_data['title_ver_bytes']
+	title_decoded         = xbe_data['title_decoded']
+	title_id_decoded      = xbe_data['title_id_decoded']
+	title_ver_decoded     = xbe_data['title_ver_decoded']
+
+	if alt_data:
+		timage_raw_bytes      = alt_data['timage_raw_bytes']
+		timage_sect_hdr_bytes = alt_data['timage_sect_hdr_bytes']
+		title_bytes           = alt_data['title_bytes']
+		title_decoded         = alt_data['title_decoded']
+
+	if timage_sect_hdr_bytes != None:
+		timage_sect_hdr_bytes = bytearray(timage_sect_hdr_bytes)
+
+	if os.path.isfile(json_file):
+		# Parse JSON and set title, fallback to filename
+		if not hasattr(gen_attach_xbe, 'title_json'):
+			title_list_fp = open(json_file)
+			gen_attach_xbe.title_json = json.load(title_list_fp)
+			title_list_fp.close()
+
+		title_json = gen_attach_xbe.title_json
+
+		title_found = False
+		for ref_json in title_json:
+			if ref_json['Title ID'] == xbe_data['title_id_decoded'] and ref_json['Version'] == xbe_data['title_ver_decoded']:
+				ref_title = ref_json['XBE Title']
+				title = ref_title.split('(', 1)[0][:-1]
+				title_bytes = format_title_bytes(title)
+				title_found = True
+				break
+
+		if not title_found and not title_decoded:
+			title_bytes = get_iso_file_title_bytes(iso_file)
+
+	# we got a blank title, fallback to iso name
+	elif not title_decoded:
+		title_bytes = get_iso_file_title_bytes(iso_file)
+
+	title_decoded = title_bytes.decode('utf-16-le').replace('\0', '')
+	title_bytes   = title_bytes[0:TITLE_MAX_LENGTH * 2]
+
+	print("Generating default.xbe - Title ID:", title_id_decoded, '- Version:', title_ver_decoded, '- Title:', title_decoded)
+
+	# patch output xbe
+	with open(in_file_name, 'rb') as f:
+		out_bytes = bytearray(f.read())
+
+	base_addr = struct.unpack('<I', out_bytes[base_addr_offset: base_addr_offset + 4])[0]
+	cert_addr = struct.unpack('<I', out_bytes[cert_addr_offset: cert_addr_offset + 4])[0]
+
+	# title
+	title_offset = cert_addr - base_addr + cert_title_offset
+	out_bytes[title_offset: title_offset + TITLE_MAX_LENGTH * 2] = title_bytes
+
+	# title id
+	title_id_offset = cert_addr - base_addr + cert_title_id_offset
+	out_bytes[title_id_offset: title_id_offset + 4] = title_id_bytes
+
+	# title version
+	title_ver_offset = cert_addr - base_addr + cert_title_ver_offset
+	out_bytes[title_ver_offset: title_ver_offset + 4] = title_ver_bytes
+
+	# title image
+	out_bytes = patch_xbe_timage_data(out_bytes, timage_sect_hdr_bytes, timage_raw_bytes)
+
+	with open(out_file_name, 'wb') as f:
+		f.write(out_bytes)
+
+	return title_decoded
+
 def main(argv):
 	infile = argv[1]
 	compress_iso(infile)
+	gen_attach_xbe(infile)
 
 if __name__ == '__main__':
 	sys.exit(main(sys.argv))


### PR DESCRIPTION
This is an updated version of PR #2 that adds support for [MakeMHz/stellar-attach](https://github.com/MakeMHz/stellar-attach). It will check for an existing `$$XTIMAGE` section and replace it with the image pulled from the iso's default.xbe (or an alternative xbe). Drop `attach.xbe` in the same folder as the `ciso.py` script and it will generate a `default.xbe` with the following pieces patched in: Title, Title ID, Version and Title Image.